### PR TITLE
Add prominent "send submission" button and redirect now to G Form

### DIFF
--- a/website/.eleventy.js
+++ b/website/.eleventy.js
@@ -1,6 +1,15 @@
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('assets')
 
+  const markdownIt = require("markdown-it")({
+    html: true,
+    breaks: true,
+    linkify: true
+  })
+  const markdownItAttrs = require("markdown-it-attrs")
+
+  eleventyConfig.setLibrary("md", markdownIt.use(markdownItAttrs))
+
   return {
     dir: {
       input: 'content',

--- a/website/assets/index.css
+++ b/website/assets/index.css
@@ -127,3 +127,13 @@ body > header {
   }
 }
 
+p.submission-link-btn {
+    margin-top: 2rem;
+}
+
+.submission-link-btn > a {
+    background-color: var(--datgreen);
+    color: #fff;
+    font-weight: bold;
+    padding: 0.8rem;
+}

--- a/website/content/2020.md
+++ b/website/content/2020.md
@@ -14,4 +14,13 @@ Dat is a protocol for peer to peer tools and a community of projects. At the fir
 
 Filling this space will be up to all of you! If you wanna do intros and presentations there’ll be a dedicated channel for prerecorded videos. For the actual conference, we’re looking for all kinds of ideas how to foster collaboration, inclusiveness and knowledge sharing, experimentation and discussion. This could be workshops, technical deep dive discussions, VR meetups, collaborative livecoding - be creative!
 
-Let’s share our approaches and talk about the present and future of local-first tech. Please submit your ideas in [as issues in our issue tracker](https://github.com/datproject/public-events/issues/new?assignees=&labels=proposal&template=proposal.md&title=), which will be accepted until **June 1st, 2020** _(23:59 PST)_. If you have any questions or want to discuss your ideas in advance, please just come by [at a comm-comm meeting](https://github.com/datproject/comm-comm/issues?q=is%3Aissue+is%3Aopen+label%3Ameeting) or come to our [public chat channel](https://dat.foundation/community/chat/).
+Let’s share our approaches and talk about the present and future of local-first tech.
+
+Please submit your ideas in [this submission form][gform-submissions], which will be accepted until **June 1st, 2020** _(23:59 PST)_. If you have any questions or want to discuss your ideas in advance, please just come by [at a comm-comm meeting](https://github.com/datproject/comm-comm/issues?q=is%3Aissue+is%3Aopen+label%3Ameeting) or come to our [public chat channel](https://dat.foundation/community/chat/).
+
+[Submit a proposal now!][gform-submissions] {.submission-link-btn}
+
+
+  [gform-submissions]: https://docs.google.com/forms/d/e/1FAIpQLSed1kHTAqgN7DvttNCEk8_BzuQvrqS3-eEJoCWS-T7wu5DqGw/viewform
+  [new-propsal-ghissue]: https://github.com/datproject/public-events/issues/new?assignees=&labels=proposal&template=proposal.md&title=
+

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "dev": "eleventy --serve"
   },
   "dependencies": {
-    "@11ty/eleventy": "^0.11.0"
+    "@11ty/eleventy": "^0.11.0",
+    "markdown-it-attrs": "^3.0.2"
   }
 }


### PR DESCRIPTION
We are now using Google Forms instead of the public issues as the main
submission mechanism, according to current decisions.