### PR TITLE
Adding code of conduct.

### DIFF
--- a/website/content/coc.md
+++ b/website/content/coc.md
@@ -22,7 +22,7 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 **Anonymous report**: Please use [this form](https://forms.gle/a8pvnrNoMCpMzqQ16) to file an anonymous report. The Safety Officers will fully investigate your report, although we will not follow up with you as the report is anonymous.
 
-**Personal report**: Please email either Diego ([diego@geutstudio.com](mailto:diego@geutstudio.com)) or Martin ([martin@consento.org](mailto:martin@consento.org) or matrix [@mh:zerc.net](@mh:zerc.net)) to file a personal report. You can also directly message either Lilly or Jonathan on the csv,conf Slack ([csvconf.slack.com](http://csvconf.slack.com)).
+**Personal report**: Please email either Diego ([diego@geutstudio.com](mailto:diego@geutstudio.com)) or Martin ([martin@consento.org](mailto:martin@consento.org) or matrix [@mh:zerc.net](@mh:zerc.net)) to file a personal report.
 
 In your report, please do your best to include:
 
@@ -37,12 +37,12 @@ In your report, please do your best to include:
 - If there is a publicly available record (e.g. mailing list record), please include a link
 - Any additional helpful information
 
-**Online Trolls**: With the move to a fully virtual conference, the risk for online trolling has increased. This behaviour is unacceptable, and the Safety Officers and conference staff will be monitoring the various chat platforms associated with csv,conf,v5 and will act decisively and swiftly to end behaviour they deem trolling. Anyone exhibiting trolling behaviour will be immediately kicked out of the conference platform (including Slack). If you believe you were accidentally kicked out, please contact us and we will review reinstatement.
+**Online Trolls**: With the move to a fully virtual conference, the risk for online trolling has increased. This behaviour is unacceptable, and the Safety Officers and conference staff will be monitoring the various chat platforms associated with dat event and will act decisively and swiftly to end behaviour they deem trolling. Anyone exhibiting trolling behaviour will be immediately kicked out of the conference platform. If you believe you were accidentally kicked out, please contact us and we will review reinstatement.
 
-**Conflicts of Interest**: If your report involves one of the csv,conf,v5 organizers or Safety Officers, or you otherwise feel like there is potential for a conflict of interest, please contact Danielle at danielle@codeforsociety.org with your report and include the above bullet point information. Danielle is serving as an impartial Code of Conduct incident reviewer for csv,conf,v5 and will fully investigate your report.
+**Conflicts of Interest**: If your report involves one of the dat event organizers or Safety Officers, or you otherwise feel like there is potential for a conflict of interest, please contact Franz at frando@unbiskant.org with your report and include the above bullet point information. Franz is serving as an impartial Code of Conduct incident reviewer for dat event and will fully investigate your report.
 
 ## Investigation
-We will fully investigate your report and follow up with you via the contact information you provide. Upon receipt of your report, the Safety Officers will immediately start the process to determine an appropriate response. If the incident is deemed urgent, the Safety Officers will coordinate with the csv,conf,v5 staff to quickly take appropriate action. This could include giving a warning to the offending party, kicking the offending party out, or referring the issue to a non-csv,conf entity, such as local police. We are unable to handle emergency situations. If the incident is less urgent, the Safety Officers will confer with the csv,conf,v5 organizing team to determine the appropriate response. 
+We will fully investigate your report and follow up with you via the contact information you provide. Upon receipt of your report, the Safety Officers will immediately start the process to determine an appropriate response. If the incident is deemed urgent, the Safety Officers will coordinate with the dat event staff to quickly take appropriate action. This could include giving a warning to the offending party, kicking the offending party out, or referring the issue to a non-dat-event entity, such as local police. We are unable to handle emergency situations. If the incident is less urgent, the Safety Officers will confer with the dat event organizing team to determine the appropriate response. 
 
 **Transparency Report**: After the conference, all reports will be summarized in an anonymized post for transparency. For example, a post would include if there were any Code of Conduct violations reported, how many violations occurred, what kinds of violations (in general terms), and if the violations were resolved. This report would not include any identifying information about the reportees.
 

--- a/website/content/coc.md
+++ b/website/content/coc.md
@@ -1,0 +1,53 @@
+# Conference Code of Conduct
+
+All attendees, speakers, sponsors, organisers and volunteers at our conference are required to agree with the following code of conduct. Safety Officers and conference staff will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everyone.
+
+Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender identity and expression, age, sexual orientation, disability, body and physical appearance, race, ethnicity, religion (or lack thereof), work experience, or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference at the discretion of the conference organisers.
+
+Harassment includes offensive verbal comments related to gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+Anything that makes someone feel uncomfortable could be deemed harassment. For more information and examples about what constitutes harassment, please refer to [OpenCon’s Code of Conduct in Brief](https://www.opencon2018.org/code_of_conduct) and the Gathering for Open Source Hardware’s [examples of behaviour](http://openhardware.science/gosh-2017/gosh-code-of-conduct/).
+
+We expect participants to follow these rules at the conference and conference-related events, including social ones. Conference staff will assist anyone experiencing harassment to ensure that everyone feels safe for the duration of the conference. We value your attendance.
+
+## Enforcement
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference. Conference staff may take action to redress anything designed to disrupt, or with the clear impact of disrupting, the event or making the environment hostile for any participants. 
+
+## Reporting
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact the dat event Safety Officers as soon as possible using the methods outlined below. We will handle all reports with discretion, and you can report anonymously if you wish. The Safety Officers are Diego Paez (Geut, Dat Consortium) and Martin Heidegger (Consento, Dat Consortium).
+
+**Anonymous report**: Please use [this form](https://forms.gle/a8pvnrNoMCpMzqQ16) to file an anonymous report. The Safety Officers will fully investigate your report, although we will not follow up with you as the report is anonymous.
+
+**Personal report**: Please email either Diego ([diego@geutstudio.com](mailto:diego@geutstudio.com)) or Martin ([martin@consento.org](mailto:martin@consento.org) or matrix [@mh:zerc.net](@mh:zerc.net)) to file a personal report. You can also directly message either Lilly or Jonathan on the csv,conf Slack ([csvconf.slack.com](http://csvconf.slack.com)).
+
+In your report, please do your best to include:
+
+- Your contact information
+- Identifying information (e.g. names, nicknames, pseudonyms) of the participant who has violated the Code of Conduct
+- The behaviour that was in violation
+- The approximate time of the behaviour (if different than the time the report was made)
+- If possible, where the Code of Conduct violation happened
+- The circumstances surrounding the incident
+- Other people involved in the incident
+- If you believe the incident is ongoing, please let us know
+- If there is a publicly available record (e.g. mailing list record), please include a link
+- Any additional helpful information
+
+**Online Trolls**: With the move to a fully virtual conference, the risk for online trolling has increased. This behaviour is unacceptable, and the Safety Officers and conference staff will be monitoring the various chat platforms associated with csv,conf,v5 and will act decisively and swiftly to end behaviour they deem trolling. Anyone exhibiting trolling behaviour will be immediately kicked out of the conference platform (including Slack). If you believe you were accidentally kicked out, please contact us and we will review reinstatement.
+
+**Conflicts of Interest**: If your report involves one of the csv,conf,v5 organizers or Safety Officers, or you otherwise feel like there is potential for a conflict of interest, please contact Danielle at danielle@codeforsociety.org with your report and include the above bullet point information. Danielle is serving as an impartial Code of Conduct incident reviewer for csv,conf,v5 and will fully investigate your report.
+
+## Investigation
+We will fully investigate your report and follow up with you via the contact information you provide. Upon receipt of your report, the Safety Officers will immediately start the process to determine an appropriate response. If the incident is deemed urgent, the Safety Officers will coordinate with the csv,conf,v5 staff to quickly take appropriate action. This could include giving a warning to the offending party, kicking the offending party out, or referring the issue to a non-csv,conf entity, such as local police. We are unable to handle emergency situations. If the incident is less urgent, the Safety Officers will confer with the csv,conf,v5 organizing team to determine the appropriate response. 
+
+**Transparency Report**: After the conference, all reports will be summarized in an anonymized post for transparency. For example, a post would include if there were any Code of Conduct violations reported, how many violations occurred, what kinds of violations (in general terms), and if the violations were resolved. This report would not include any identifying information about the reportees.
+
+## Confidentiality
+All reports will be kept confidential. When we discuss incidents with people who are reported, we will anonymize details as much as we can to protect reporter privacy. In some cases we may determine that a public statement will need to be made. If that’s the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+## Acknowledgments
+This Code of Conduct is adapted from the [Conference Code of Conduct](https://confcodeofconduct.com/) (CC BY 3.0), the [eLife Sprint Code of Conduct](https://sprint.elifesciences.org/code-of-conduct/) (CC BY 4.0), and the [PyCon Code of Conduct](https://us.pycon.org/2020/about/code-of-conduct/) (CC BY-SA 3.0).


### PR DESCRIPTION
This PR adds a code of conduct based on the csvconf's code-of-conduct.

It contains me and @dpaez as CoC officers and @Frando for conflicts of interests - please confirm the addresses and if the current use is okay.