### PR TITLE
Add many-pages structure for 2020 event

### DIFF
--- a/website/content/2020/agenda.md
+++ b/website/content/2020/agenda.md
@@ -1,0 +1,12 @@
+---
+title: Agenda · Dat Conference 2020
+layout: layout-2020
+---
+
+# Agenda for the Dat Conference 2020
+
+The agenda is not yet available, keep tuned!
+
+If you want to keep tuned, you can subscribe to our newsletter!
+
+{% include newsletter %}

--- a/website/content/2020/coc.md
+++ b/website/content/2020/coc.md
@@ -1,3 +1,8 @@
+---
+title: Code of Conduct · Dat Conference 2020
+layout: layout-2020
+---
+
 # Conference Code of Conduct
 
 All attendees, speakers, sponsors, organisers and volunteers at our conference are required to agree with the following code of conduct. Safety Officers and conference staff will enforce this code throughout the event. We expect cooperation from all participants to help ensure a safe environment for everyone.

--- a/website/content/2020/index.md
+++ b/website/content/2020/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dat Conference 2020
-layout: layout
+layout: layout-2020
 ---
 
 ## Dat Conference 2020

--- a/website/includes/layout-2020.liquid
+++ b/website/includes/layout-2020.liquid
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>{{ title }}</title>
+        <link rel="stylesheet" href="{{ '/assets/normalize.css' | url }}">
+        <link rel="stylesheet" href="{{ '/assets/index.css' | url }}">
+    </head>
+    <body>
+      <header>
+        <nav id="menu">
+          <a id="menu-dat-link" href="/" aria-label="Dat events index" style="margin:0"></a>
+          <a href="/2020/">About</a>
+          <a href="/2020/agenda/">Agenda</a>
+          <a href="/2020/coc/">Code of conduct</a>
+        </nav>
+      </header>
+      <main>
+        {{ content }}
+      </main>
+  </body>
+</html>

--- a/website/includes/newsletter.liquid
+++ b/website/includes/newsletter.liquid
@@ -1,0 +1,22 @@
+  <div class="newsletter-signup">
+    <h3 class="newsletter-signup__header">
+      Sign up for our monthly newsletter!
+    </h3>
+    <div class="newsletter-signup__cta">
+      Get updates from the Dat Foundation in your inbox each month! You can <a href="https://us16.campaign-archive.com/home/?u=993df3c1e35c9b224b64ccf72&id=0b92b85247" title="View previous campaigns" target="_blank" rel="noopener">read</a> newsletters from past months or <a href="https://github.com/datproject/newsletter" target="_blank" rel="noopener">learn</a> how you can contribute here.
+    </div>
+    <!-- Begin Mailchimp Signup Form -->
+    <div id="mc_embed_signup">
+      <form action="https://datproject.us16.list-manage.com/subscribe/post?u=993df3c1e35c9b224b64ccf72&amp;id=0b92b85247" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter-sign__form" target="_blank" novalidate>
+        <input type="email" value="" name="EMAIL" class="required email newsletter-signup__email" id="mce-EMAIL">
+        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_993df3c1e35c9b224b64ccf72_0b92b85247" tabindex="-1" value=""></div>
+        <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button">
+        <div id="mce-responses" class="clear">
+        <div class="response" id="mce-error-response" style="display:none"></div>
+        <div class="response" id="mce-success-response" style="display:none"></div>
+        </div>    
+      </form>
+    </div>
+    <!--End mc_embed_signup-->
+  </div>


### PR DESCRIPTION
- Link CoC on website
- Add agenda and redesign top navbar to include all page elements
- Logo keeps its old behavior to go to the root of the events page
- Adds the newsletter as a template
  - Need to investigate how to cleanly add CSS in templates (or
    SCSS) or if we need to just add it to the page