### PR TITLE
Stream link to youtube and a third-party-cookie test

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,6 +32,12 @@
   status = 301
   force = true
 
+[[redirects]]
+  from = "/2020/stream/"
+  to = "https://www.youtube.com/watch?v=Cm9fwxnXg9k&list=PL7sG5SCUNyeYx8wnfMOUpsh7rM_g0w_c"
+  status = 302
+  force = true
+
 [build.processing]
   skip_processing = false
 [build.processing.css]

--- a/website/assets/index-2020.css
+++ b/website/assets/index-2020.css
@@ -576,3 +576,23 @@ ul.speaker-list svg.speaker-image {
   font-size: 1.15em;
   color: var(--darkmain);
 }
+
+.tpc-ok-only {
+  display: none;
+}
+.tpc-fail-only {
+  display: none;
+}
+.tpc-loading {
+  display: block;
+}
+body.tpc-ok .tpc-loading,
+body.tpc-fail .tpc-loading {
+  display: none;
+}
+body.tpc-ok .tpc-ok-only {
+  display: block;
+}
+body.tpc-fail .tpc-fail-only {
+  display: block;
+}

--- a/website/content/2020/stream.html
+++ b/website/content/2020/stream.html
@@ -15,7 +15,11 @@ layout: layout-2020
 </div>
 <div class="tpc-fail-only">
   <p>It seems we cannot embed a YouTube video with your current browser settings.</p>
-  <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">Come follow our live-stream on Youtube!</a>
+  <p>
+    We have checked that you don't allow third-party cookies being set. This prevents websites such as YouTube from properly working when embedded from this page
+    In order to respect that choice, you will have to see the event live-stream there from your browser.
+  </p>
+  <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">You can watcn the live-stream on Youtube from this link!</a>
 </div>
 <iframe class="tpc-ok-only" width="100%" height="410" src="https://www.youtube.com/embed/videoseries?list={{ playlist }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 <script type="text/javascript">

--- a/website/content/2020/stream.html
+++ b/website/content/2020/stream.html
@@ -21,7 +21,7 @@ layout: layout-2020
   </p>
   <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">You can watcn the live-stream on Youtube from this link!</a>
 </div>
-<iframe class="tpc-ok-only" width="100%" height="410" src="https://www.youtube.com/embed/videoseries?list={{ playlist }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe class="tpc-ok-only" style="width: 100vw; height: 100vh;" src="https://www.youtube.com/embed/videoseries?list={{ playlist }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 <script type="text/javascript">
 ;(function () {
   if (document.getElementById('tpc-test')) {
@@ -52,3 +52,37 @@ layout: layout-2020
   body.appendChild(step1)
 })()
 </script>
+<style type="text/css">
+  html {
+    overflow: hidden;
+  }
+  body {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    width: 100vw;
+  }
+  iframe {
+    background: url('/assets/loading.gif') no-repeat center, #F8F7FA;
+    border: 1px solid #eeedf2;
+    border-top: 0;
+    border-bottom: 0;
+    width: 100%
+  }
+  
+  body > main {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  @media only screen and (max-width: 44rem) {
+    iframe {
+      border: 0;
+    }
+  }
+  #eventbrite-widget-container-112923713868 {
+    max-width: 48rem;
+    height: 100% !important;
+  }
+</style>

--- a/website/content/2020/stream.html
+++ b/website/content/2020/stream.html
@@ -3,6 +3,11 @@ title: Stream
 layout: layout-2020
 ---
 {% assign playlist = "PL7sG5SCUNyeYx8wnfMOUpsh7rM_g0w_cu" %}
+{% capture ytlink %}https://www.youtube.com/watch?v=Cm9fwxnXg9k&list={{playlist}}{% endcapture %}
+{% comment %}
+
+<!-- Doesn't work with Youtube \_(-_-)_/ -->
+
 <div class="tpc-loading">
   <h3>Loading live stream...</h3>
   <p>
@@ -97,3 +102,10 @@ layout: layout-2020
     height: 100% !important;
   }
 </style>
+{% endcomment %}
+<script type="text/javascript">
+  setTimeout(function () {
+    document.location.href = "{{ytlink}}"
+  }, 10)
+</script>
+

--- a/website/content/2020/stream.html
+++ b/website/content/2020/stream.html
@@ -4,12 +4,20 @@ layout: layout-2020
 ---
 {% assign playlist = "PL7sG5SCUNyebK_ip9gGJvf8HOpe1cpmyn" %}
 <div class="tpc-loading">
-  Loading.
+  <h3>Loading live stream...</h3>
+  <p>
+    We are finding out if your browser can see the YouTube video
+    embedded. You need to enable third-party cookies for this to work.
+  </p>
+  <p>If you are blocking third-party network requests, this will never load.</p>
+  <p>Too slow/not working? See the event directly from <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">the YouTube playlist</a>.</p>
+
 </div>
 <div class="tpc-fail-only">
-  <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">Follow our live-stream on Youtube!</a>
+  <p>It seems we cannot embed a YouTube video with your current browser settings.</p>
+  <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">Come follow our live-stream on Youtube!</a>
 </div>
-<iframe class="tpc-ok-only" width="100%" height="315" src="https://www.youtube.com/embed/videoseries?list={{ playlist }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe class="tpc-ok-only" width="100%" height="410" src="https://www.youtube.com/embed/videoseries?list={{ playlist }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 <script type="text/javascript">
 ;(function () {
   if (document.getElementById('tpc-test')) {

--- a/website/content/2020/stream.html
+++ b/website/content/2020/stream.html
@@ -2,7 +2,41 @@
 title: Stream
 layout: layout-2020
 ---
+{% assign playlist = "PL7sG5SCUNyebK_ip9gGJvf8HOpe1cpmyn" %}
+<div class="tpc-loading">
+  Loading.
+</div>
+<div class="tpc-fail-only">
+  <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">Follow our live-stream on Youtube!</a>
+</div>
+<iframe class="tpc-ok-only" width="100%" height="315" src="https://www.youtube.com/embed/videoseries?list={{ playlist }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<script type="text/javascript">
+;(function () {
+  if (document.getElementById('tpc-test')) {
+    // Prevent duplicate execution
+    return
+  }
+  const body = document.body
+  const tpcDomain = '//tpc.consento.org/'
+  const step1 = document.createElement('script')
+  step1.setAttribute('src', tpcDomain + 'step1.js')
+  const step2 = document.createElement('script')
+  step2.setAttribute('src', tpcDomain + 'step2.js')
 
-<p>
-  Our stream will go online on July 31'st, stay tuned.
-</p>
+  window._3rd_party_test_step1_loaded = function () {
+    body.classList.add('tpc-step-2')
+    body.classList.remove('tpc-step-1')
+    body.removeChild(step1)
+    body.appendChild(step2)
+  }
+  window._3rd_party_test_step2_loaded = function (cookieSuccess) {
+    body.classList.toggle('tpc-ok', cookieSuccess)
+    body.classList.toggle('tpc-fail', !cookieSuccess)
+    body.classList.remove('tpc-step-2')
+    body.removeChild(step2)
+  }
+
+  body.classList.add('tpc-step-1')
+  body.appendChild(step1)
+})()
+</script>

--- a/website/content/2020/stream.html
+++ b/website/content/2020/stream.html
@@ -19,9 +19,9 @@ layout: layout-2020
     We have checked that you don't allow third-party cookies being set. This prevents websites such as YouTube from properly working when embedded from this page
     In order to respect that choice, you will have to see the event live-stream there from your browser.
   </p>
-  <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">You can watcn the live-stream on Youtube from this link!</a>
+  <a href="https://www.youtube.com/watch?v=VNisTWqjuoI&list={{ playlist }}">You can watch the live-stream on Youtube from this link!</a>
 </div>
-<iframe class="tpc-ok-only" style="width: 100vw; height: 100vh;" src="https://www.youtube.com/embed/videoseries?list={{ playlist }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe class="tpc-ok-only" src="https://www.youtube.com/embed/videoseries?list={{ playlist }}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 <script type="text/javascript">
 ;(function () {
   if (document.getElementById('tpc-test')) {
@@ -73,6 +73,17 @@ layout: layout-2020
   body > main {
     max-width: none;
     margin: 0;
+    padding: 0;
+    display: flex;
+    flex-grow: 1;
+  }
+  body > header {
+    height: 126px;
+  }
+
+  .tpc-fail-only, .tpc-loading {
+    max-width: 44rem;
+    margin: auto;
     padding: 0;
   }
 

--- a/website/content/2020/stream.html
+++ b/website/content/2020/stream.html
@@ -103,6 +103,9 @@ layout: layout-2020
   }
 </style>
 {% endcomment %}
+<p>
+  Redirecting to <a href="{{ytlink}}">{{ytlink}}</a>
+</p>
 <script type="text/javascript">
   setTimeout(function () {
     document.location.href = "{{ytlink}}"

--- a/website/content/2020/stream.html
+++ b/website/content/2020/stream.html
@@ -2,7 +2,7 @@
 title: Stream
 layout: layout-2020
 ---
-{% assign playlist = "PL7sG5SCUNyebK_ip9gGJvf8HOpe1cpmyn" %}
+{% assign playlist = "PL7sG5SCUNyeYx8wnfMOUpsh7rM_g0w_cu" %}
 <div class="tpc-loading">
   <h3>Loading live stream...</h3>
   <p>

--- a/website/plugins/pretalx-fetch/runfetch.js
+++ b/website/plugins/pretalx-fetch/runfetch.js
@@ -142,9 +142,12 @@ module.exports = async function (base, { conferences, ttl, targetDomain, personP
       return {
         code: talk.code,
         title: talk.title,
+        abstract: talk.abstract,
+        description: talk.description,
         byLine: `by ${byLine(talk.speakers)}`,
         url: `https://${targetDomain}/${prefix}/talk/${talk.code}`,
-        time: `${formatter.format(Temporal.DateTime.from(talk.slot.start))} (${timezone})`
+        time: `${formatter.format(Temporal.DateTime.from(talk.slot.start))} (${timezone})`,
+        timeMS: Temporal.Absolute.from(talk.slot.start).getEpochMilliseconds() 
       }
     })
     const jsonPath = `${base}/content/_data/${prefix}/talks_simple.json`


### PR DESCRIPTION
Adding a playlist embed to the stream page showing the youtube embed if third-party-cookies are supported and a link if not.

TODO:

- [ ] replace with live playlist
- [x] properly size the embed to use a good amount of space.
- [x] show a nicer link to youtube for the stream with information why it can't be embedded (disabled-third-party-cookies)
- [x] show a nicer loading screen